### PR TITLE
Fix week dropdown mismatch

### DIFF
--- a/app.py
+++ b/app.py
@@ -337,7 +337,9 @@ def result():
         is_history_page=True,
         event_totals=event_totals
     )
-    week_options = [(week_name, week_name) for (_, _, week_name, _) in sorted_attendance_data]
+    week_options = [
+        (idx, week_name) for idx, (_, _, week_name, _) in enumerate(sorted_attendance_data)
+    ]
     logger.info(f"Generated week_options: {week_options}")
     return render_template(
         'result.html',

--- a/templates/result.html
+++ b/templates/result.html
@@ -13,14 +13,14 @@
         <h2>統計結果</h2>
         <div class="table-container">
             <div class="week-selector-container">
-				<select id="weekSelector" class="week-selector">
-				{% for week_name, value in week_options %}
-					<option value="{{ value }}"
-							{% if week_name == selected_week_display %}selected{% endif %}>
-						{{ week_name }}
-					</option>
-				{% endfor %}
-			</select>
+                             <select id="weekSelector" class="week-selector">
+                             {% for idx, week_name in week_options %}
+                                     <option value="{{ idx }}"
+                                                     {% if week_name == selected_week_display %}selected{% endif %}>
+                                             {{ week_name }}
+                                     </option>
+                             {% endfor %}
+                     </select>
             </div>
             <div id="attendanceTable">
                 {{ attendance_table_html | safe }}
@@ -43,14 +43,14 @@
 
     <script>
         function updateTable() {
-			const weekStr = $('#weekSelector').val();           // ← 用字串
-			$.ajax({
-				url: '/get_week_data_by_name/' + encodeURIComponent(weekStr),
-				type: 'GET',
-				success: res => $('#attendanceTable').html(res.attendance_table || '<p>無資料</p>'),
-				error: () => $('#attendanceTable').html('<p>載入失敗</p>')
-			});
-		}
+                     const weekIdx = $('#weekSelector').val();
+                     $.ajax({
+                             url: '/get_week_data/' + weekIdx,
+                             type: 'GET',
+                             success: res => $('#attendanceTable').html(res.attendance_table || '<p>無資料</p>'),
+                             error: () => $('#attendanceTable').html('<p>載入失敗</p>')
+                     });
+             }
 
         $(document).ready(()=>$('#weekSelector').on('change', updateTable));
     </script>


### PR DESCRIPTION
## Summary
- build week selector options using numeric index instead of week string
- fetch attendance data with the numeric index

## Testing
- `python3 -m py_compile app.py excel_handler.py render_table.py utils.py admin_routes.py database.py user.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_6859056ed4708321b5f774a61f3c14ad