### PR TITLE
Fix week dropdown selection after upload

### DIFF
--- a/templates/history.html
+++ b/templates/history.html
@@ -63,7 +63,8 @@
                                 $('#weekSelector').html(options);
                                 $('#weekSelector').prop('disabled', false);
                                 if (initialWeek) {
-                                    $('#weekSelector').val(initialWeek).trigger('change');
+                                    const encoded = encodeURIComponent(initialWeek);
+                                    $('#weekSelector').val(encoded).trigger('change');
                                     initialWeek = null;
                                 }
                             } else {


### PR DESCRIPTION
## Summary
- ensure history page can match week param from redirect by encoding it before selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a03a85e408321a594eec336449b05