### PR TITLE
Add yearly average attendance page

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,11 @@ import uuid
 import os
 from concurrent.futures import ThreadPoolExecutor
 from excel_handler import process_excel, generate_excel
-from render_table import render_attendance_table, render_average_attendance_table
+from render_table import (
+    render_attendance_table,
+    render_average_attendance_table,
+    render_year_average_attendance_table,
+)
 from database import (
     init_database,
     get_six_month_averages,
@@ -14,6 +18,8 @@ from database import (
     get_six_month_trimmed_mean,
     get_six_month_trimmed_mean_by_event,
     get_six_month_trimmed_mean_by_age_group,
+    get_year_trimmed_mean_by_event,
+    get_year_trimmed_mean_by_age_group,
 )
 from user import init_users_collection, create_user, verify_user, create_admin_if_not_exists
 from config import db, DB_OFFLINE, COLLECTION_NAME
@@ -549,6 +555,46 @@ def average_attendance():
             is_anonymous=is_anonymous
         )
 
+
+@app.route('/yearly_average_attendance')
+def yearly_average_attendance():
+    if not is_authenticated():
+        return redirect(url_for('login'))
+
+    if DB_OFFLINE:
+        return render_template('index.html',
+                               error="資料庫離線，無法查看全年平均出席",
+                               version=get_version_info(), is_anonymous=True)
+
+    is_anonymous = session.get('user', {}).get('role') == 'anonymous'
+    if is_anonymous:
+        return render_template('index.html', error="匿名使用者無法查看全年平均出席", version=get_version_info(), is_anonymous=True)
+
+    try:
+        districts = db[COLLECTION_NAME].distinct("district")
+        main_districts = sorted(
+            set(parse_district(d)[0] for d in districts if parse_district(d)[0]),
+            key=lambda x: chinese_to_int(x[0])
+        )
+
+        weeks = db[COLLECTION_NAME].distinct("week_display")
+        years = sorted({parse_week_display(w)[0] for w in weeks if parse_week_display(w)[0]})
+
+        return render_template(
+            'yearly_average_attendance.html',
+            main_districts=main_districts,
+            years=years,
+            version=get_version_info()
+        )
+    except Exception as e:
+        logger.error(f"Failed to load yearly average attendance page: {str(e)}")
+        return render_template(
+            'index.html',
+            error="無法載入全年平均出席頁面",
+            version=get_version_info(),
+            is_anonymous=is_anonymous
+        )
+
 @app.route('/get_weeks_for_district/<district>')
 def get_weeks_for_district(district):
     if not is_authenticated():
@@ -762,6 +808,52 @@ def get_average_attendance_data(district, date):
         return jsonify({"error": "無效的日期格式"}), 400
     except Exception as e:
         logger.error(f"Failed to get average attendance data for {district} on {date}: {str(e)}")
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route('/get_year_average_attendance_data/<district>/<int:year>')
+def get_year_average_attendance_data(district, year):
+    if not is_authenticated():
+        return jsonify({"error": "請先登入"}), 401
+
+    is_anonymous = session.get('user', {}).get('role') == 'anonymous'
+    if is_anonymous:
+        return jsonify({"error": "匿名使用者無法訪問此資源"}), 403
+
+    try:
+        end_date = datetime(year, 12, 31)
+        now = datetime.now()
+        if end_date > now:
+            end_date = now
+
+        event_names = db[COLLECTION_NAME].distinct("event_name")
+        trimmed_mean_data_list = []
+        for event in event_names:
+            if event == "未指定活動":
+                continue
+            data = get_year_trimmed_mean_by_event(district, end_date, event)
+            if any(data["districts"].values()) or data["counts"].get(district):
+                trimmed_mean_data_list.append(data)
+
+        age_group_data = get_year_trimmed_mean_by_age_group(district, end_date)
+
+        if not trimmed_mean_data_list:
+            logger.warning(f"No yearly average attendance data for {district} in {year}")
+            return jsonify({
+                'attendance_table': '<div class="district-section"><table class="excel-table"><tr class="title-row"><th>無資料</th></tr></table></div>'
+            }), 404
+
+        trimmed_mean_data_list.sort(key=lambda x: x['event_name'])
+        attendance_table_html = render_year_average_attendance_table(
+            district,
+            end_date,
+            trimmed_mean_data_list,
+            age_group_data,
+        )
+        logger.info(f"Rendered yearly average attendance data for {district} in {year}")
+        return jsonify({'attendance_table': attendance_table_html})
+    except Exception as e:
+        logger.error(f"Failed to get yearly average attendance data for {district}, {year}: {str(e)}")
         return jsonify({"error": str(e)}), 500
 
 if __name__ == '__main__':

--- a/database.py
+++ b/database.py
@@ -491,3 +491,149 @@ def get_six_month_trimmed_mean_by_age_group(main_district, end_date):
             f"Failed to calculate trimmed mean by age for {main_district}: {str(e)}"
         )
         return {age: {} for age in ['青職以上', '大專', '中學', '小學', '學齡前']}
+
+
+def get_year_trimmed_mean(main_district, end_date):
+    """Calculate trimmed mean attendance for '主日' over one year."""
+    return get_year_trimmed_mean_by_event(main_district, end_date, event_name="主日")
+
+
+def get_year_trimmed_mean_by_event(main_district, end_date, event_name):
+    """Calculate trimmed mean attendance per district for a specific event over one year."""
+    try:
+        logger.debug(f"Calculating yearly trimmed mean for {main_district}, event: {event_name}, up to {end_date}")
+        one_year_ago = end_date - timedelta(days=365)
+        year = one_year_ago.year
+        month = one_year_ago.month
+        week_num = (one_year_ago.day - 1) // 7 + 1
+        week_start = f"{year}年{month:02d}月第{week_num}週"
+
+        districts = db[COLLECTION_NAME].distinct("district", {
+            "district": {"$regex": f"^{main_district}"},
+            "event_name": event_name
+        })
+
+        result = {
+            "districts": {},
+            "main_district": main_district,
+            "counts": {},
+            "event_name": event_name
+        }
+
+        for district in districts:
+            pipeline = [
+                {"$match": {
+                    "district": district,
+                    "week_display": {"$gte": week_start},
+                    "event_name": event_name,
+                    "attended": 1
+                }},
+                {"$group": {"_id": "$week_display", "count": {"$sum": 1}}}
+            ]
+            weekly_counts = list(db[COLLECTION_NAME].aggregate(pipeline))
+            counts = [r["count"] for r in weekly_counts]
+            if not counts:
+                result["districts"][district] = 0
+                continue
+
+            counts.sort()
+            n = len(counts)
+            trim = int(n * 0.1)
+            trimmed_counts = counts[trim:n - trim] if n > 2 * trim else counts
+            mean = round(sum(trimmed_counts) / len(trimmed_counts)) if trimmed_counts else 0
+            result["districts"][district] = mean
+
+        pipeline = [
+            {"$match": {
+                "district": {"$regex": f"^{main_district}"},
+                "week_display": {"$gte": week_start},
+                "event_name": event_name,
+                "attended": 1
+            }},
+            {"$group": {"_id": "$week_display", "count": {"$sum": 1}}}
+        ]
+        weekly_counts = list(db[COLLECTION_NAME].aggregate(pipeline))
+        counts = [r["count"] for r in weekly_counts]
+        if counts:
+            counts.sort()
+            n = len(counts)
+            trim = int(n * 0.1)
+            trimmed_counts = counts[trim:n - trim] if n > 2 * trim else counts
+            mean = round(sum(trimmed_counts) / len(trimmed_counts)) if trimmed_counts else 0
+            result["counts"][main_district] = mean
+        else:
+            result["counts"][main_district] = 0
+
+        logger.info(f"Year trimmed mean for {main_district}, event: {event_name}: {result}")
+        return result
+    except Exception as e:
+        logger.error(f"Failed to calculate yearly trimmed mean for {main_district}, event: {event_name}: {str(e)}")
+        return {"districts": {}, "main_district": main_district, "counts": {}, "event_name": event_name}
+
+
+def get_year_trimmed_mean_by_age_group(main_district, end_date):
+    """Calculate trimmed mean attendance per age group for the last year."""
+    try:
+        age_categories = ['青職以上', '大專', '中學', '小學', '學齡前']
+        one_year_ago = end_date - timedelta(days=365)
+        year = one_year_ago.year
+        month = one_year_ago.month
+        week_num = (one_year_ago.day - 1) // 7 + 1
+        week_start = f"{year}年{month:02d}月第{week_num}週"
+
+        districts = db[COLLECTION_NAME].distinct(
+            "district",
+            {"district": {"$regex": f"^{main_district}"}, "event_name": "主日"}
+        )
+
+        def _trimmed_mean(values):
+            if not values:
+                return 0
+            values.sort()
+            n = len(values)
+            trim = int(n * 0.1)
+            trimmed = values[trim:n - trim] if n > 2 * trim else values
+            return round(sum(trimmed) / len(trimmed)) if trimmed else 0
+
+        result = {age: {} for age in age_categories}
+
+        for district in districts:
+            pipeline = [
+                {"$match": {
+                    "district": district,
+                    "week_display": {"$gte": week_start},
+                    "event_name": "主日",
+                    "attended": 1
+                }},
+                {"$group": {"_id": {"age_group": "$age_group", "week_display": "$week_display"}, "count": {"$sum": 1}}},
+                {"$group": {"_id": "$_id.age_group", "weekly": {"$push": "$count"}}}
+            ]
+            age_results = list(db[COLLECTION_NAME].aggregate(pipeline))
+            for doc in age_results:
+                age = doc["_id"] or '青職以上'
+                if age not in age_categories:
+                    age = '青職以上'
+                result[age][district] = _trimmed_mean(doc.get("weekly", []))
+
+        pipeline = [
+            {"$match": {
+                "district": {"$regex": f"^{main_district}"},
+                "week_display": {"$gte": week_start},
+                "event_name": "主日",
+                "attended": 1
+            }},
+            {"$group": {"_id": {"age_group": "$age_group", "week_display": "$week_display"}, "count": {"$sum": 1}}},
+            {"$group": {"_id": "$_id.age_group", "weekly": {"$push": "$count"}}}
+        ]
+        age_results = list(db[COLLECTION_NAME].aggregate(pipeline))
+        for doc in age_results:
+            age = doc["_id"] or '青職以上'
+            if age not in age_categories:
+                age = '青職以上'
+            result[age][main_district] = _trimmed_mean(doc.get("weekly", []))
+
+        logger.info(f"Year trimmed mean by age for {main_district}: {result}")
+        return result
+    except Exception as e:
+        logger.error(f"Failed to calculate yearly trimmed mean by age for {main_district}: {str(e)}")
+        return {age: {} for age in ['青職以上', '大專', '中學', '小學', '學齡前']}

--- a/render_table.py
+++ b/render_table.py
@@ -358,3 +358,129 @@ def render_average_attendance_table(main_district, end_date, trimmed_mean_data_l
     html += '</table>\n</div>\n'   # end stats-wrapper
     html += '</div>\n</div>\n'     # end container / section
     return html
+
+
+def render_year_average_attendance_table(main_district, end_date, trimmed_mean_data_list, age_group_data):
+    """Render the yearly average attendance table, similar to the six month version."""
+    one_year_ago = end_date - timedelta(days=365)
+    start_date_str = one_year_ago.strftime('%Y-%m-%d')
+    end_date_str = end_date.strftime('%Y-%m-%d')
+
+    pipeline = [
+        {"$match": {
+            "district": {"$regex": f"^{main_district}"},
+            "event_name": "主日",
+            "date": {"$gte": start_date_str, "$lte": end_date_str}
+        }},
+        {"$group": {
+            "_id": {"district": "$district", "name": "$name"},
+            "attendance_rate": {"$avg": {"$cond": [{"$eq": ["$attended", 1]}, 1, 0]}}
+        }}
+    ]
+    name_records = list(db[COLLECTION_NAME].aggregate(pipeline))
+
+    districts = sorted({r["_id"]["district"] for r in name_records if r["_id"]["district"].startswith(main_district)}, key=parse_district)
+    if not districts:
+        return ('<div class="district-section"><table class="excel-table">'
+                '<tr class="title-row"><th>No data</th></tr></table></div>')
+
+    district_names = {d: [] for d in districts}
+    for rec in name_records:
+        d = rec["_id"]["district"]
+        if d in district_names:
+            district_names[d].append((rec["_id"]["name"], rec["attendance_rate"]))
+    for d in district_names:
+        district_names[d].sort(key=lambda x: -x[1])
+
+    max_len = max(len(lst) for lst in district_names.values())
+    num_sub_districts = len(districts)
+    total_cols = num_sub_districts * 2
+
+    html = (
+        '<div class="district-section">\n'
+        f'<h2>{main_district} — 1-Year Avg Attendance (through {end_date_str})</h2>\n'
+        f'<div class="district-container flex-container" '
+        f'style="--num-sub-districts:{num_sub_districts}; --num-districts:{num_sub_districts + 1};">\n'
+        f'<div class="table-wrapper attendance-wrapper flex-item" '
+        f'style="--num-sub-districts:{num_sub_districts};">\n'
+        '<table class="excel-table">\n'
+        f'<tr class="header"><th colspan="{total_cols}">{main_district}</th></tr>\n'
+        '<tr class="district-row">\n'
+    )
+    for d in districts:
+        html += f'<th colspan="2">{d}</th>'
+    html += '</tr>\n<tr class="subheader">\n'
+    html += ''.join('<th>姓名</th><th>到會率</th>' for _ in districts)
+    html += '</tr>\n'
+
+    for r in range(max_len):
+        row_cls = "even" if r % 2 == 0 else "odd"
+        html += f'<tr class="{row_cls}">\n'
+        for d in districts:
+            name, rate = district_names[d][r] if r < len(district_names[d]) else ('', 0.0)
+            display = name[:4] if len(name) > 4 else name
+            html += f'<td>{display}</td><td>{rate:.0%}</td>'
+        html += '</tr>\n'
+    html += '</table>\n</div>\n'
+
+    num_districts = num_sub_districts + 3
+    html += (
+        f'<div class="table-wrapper stats-wrapper flex-item" '
+        f'style="--num-districts:{num_districts};">\n'
+        '<table class="excel-table">\n'
+        '<tr class="header"><th style="min-width:2em">Avg</th><th></th>'
+        f'<th style="min-width:1em">{main_district}</th>'
+    )
+    for d in districts:
+        html += f'<th style="min-width:1em">{d}</th>'
+    html += '</tr>\n'
+
+    row_index = 0
+    age_categories = ['青職以上', '大專', '中學', '小學', '學齡前']
+    for data in trimmed_mean_data_list:
+        if not any(data["districts"].values()) and not data["counts"].get(main_district):
+            continue
+        event_name = data["event_name"]
+        if event_name == "主日":
+            rowspan = len(age_categories) + 1
+            for idx, age in enumerate(age_categories):
+                row_cls = "even" if row_index % 2 == 0 else "odd"
+                if idx == 0:
+                    html += (
+                        f'<tr class="{row_cls}"><td rowspan="{rowspan}" style="min-width:2em">{event_name}</td>'
+                        f'<td style="min-width:2em">{age}</td>'
+                        f'<td style="min-width:1em">{age_group_data.get(age, {}).get(main_district, 0)}</td>'
+                    )
+                else:
+                    html += (
+                        f'<tr class="{row_cls}"><td style="min-width:2em">{age}</td>'
+                        f'<td style="min-width:1em">{age_group_data.get(age, {}).get(main_district, 0)}</td>'
+                    )
+                for d in districts:
+                    html += f'<td style="min-width:1em">{age_group_data.get(age, {}).get(d, 0)}</td>'
+                html += '</tr>\n'
+                row_index += 1
+
+            row_cls = "even" if row_index % 2 == 0 else "odd"
+            html += (
+                f'<tr class="{row_cls}"><td style="min-width:2em">總數</td>'
+                f'<td style="min-width:1em">{data["counts"].get(main_district, 0)}</td>'
+            )
+            for d in districts:
+                html += f'<td style="min-width:1em">{data["districts"].get(d, 0)}</td>'
+            html += '</tr>\n'
+            row_index += 1
+        else:
+            row_cls = "even" if row_index % 2 == 0 else "odd"
+            html += (
+                f'<tr class="{row_cls}"><td style="min-width:2em">{event_name}</td><td></td>'
+                f'<td style="min-width:1em">{data["counts"].get(main_district, 0)}</td>'
+            )
+            for d in districts:
+                html += f'<td style="min-width:1em">{data["districts"].get(d, 0)}</td>'
+            html += '</tr>\n'
+            row_index += 1
+
+    html += '</table>\n</div>\n'
+    html += '</div>\n</div>\n'
+    return html

--- a/templates/yearly_average_attendance.html
+++ b/templates/yearly_average_attendance.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+    <meta charset="UTF-8">
+    <title>全年平均出席統計</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</head>
+<body>
+    <div class="container">
+        <h2>全年平均出席統計</h2>
+        <div class="table-container">
+            <div class="week-selector-container">
+                <label for="yearSelector">選擇年度：</label>
+                <select id="yearSelector" class="week-selector">
+                    <option value="">請選擇年度</option>
+                    {% for y in years %}
+                        <option value="{{ y }}">{{ y }}</option>
+                    {% endfor %}
+                </select>
+                <label for="districtSelector" style="margin-left: 20px;">選擇大區：</label>
+                <select id="districtSelector" class="week-selector">
+                    <option value="">請選擇大區</option>
+                    {% for district in main_districts %}
+                        <option value="{{ district }}">{{ district }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div id="attendanceTable">
+                <p>請選擇年度和大區以顯示數據</p>
+            </div>
+        </div>
+        <div class="button-container">
+            <a href="{{ url_for('index') }}" class="button">返回上傳頁面</a>
+            <a href="{{ url_for('logout') }}" class="button">登出</a>
+        </div>
+    </div>
+    <footer style="text-align: center; margin-top: 20px;">
+        <p>版本: {{ version }}</p>
+    </footer>
+
+    <script>
+        $(document).ready(function() {
+            $('#yearSelector, #districtSelector').on('change', function() {
+                var year = $('#yearSelector').val();
+                var district = $('#districtSelector').val();
+                $('#attendanceTable').html('<p>正在載入數據...</p>');
+
+                if (year && district) {
+                    $.ajax({
+                        url: '/get_year_average_attendance_data/' + encodeURIComponent(district) + '/' + year,
+                        type: 'GET',
+                        success: function(response) {
+                            if (response.attendance_table) {
+                                $('#attendanceTable').html(response.attendance_table);
+                                console.log('平均出席表格更新成功');
+                            } else {
+                                $('#attendanceTable').html('<p>無可用數據</p>');
+                            }
+                        },
+                        error: function(xhr) {
+                            $('#attendanceTable').html('<p>無法載入數據：' + (xhr.responseJSON?.error || '伺服器錯誤') + '</p>');
+                        }
+                    });
+                } else {
+                    $('#attendanceTable').html('<p>請選擇年度和大區以顯示數據</p>');
+                }
+            });
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add template for yearly averages
- support yearly average trimmed mean calculations in database layer
- add table rendering for yearly period
- expose new routes for yearly average pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b255ab4d48321abbabc089ee11eed