### PR TITLE
Add CSRF protection

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, request, jsonify, send_file, redirect, url_for, session, render_template
 from flask_session import Session
+from flask_wtf.csrf import CSRFProtect
 from io import BytesIO
 import uuid
 import os
@@ -33,6 +34,10 @@ app = Flask(__name__)
 app.config['SESSION_TYPE'] = 'filesystem'
 app.config['SECRET_KEY'] = os.getenv('SECRET_KEY', 'your-secret-key-here')
 Session(app)
+CSRFProtect(app)
+app.config['SESSION_COOKIE_HTTPONLY'] = True
+app.config['SESSION_COOKIE_SAMESITE'] = 'Lax'
+app.config['SESSION_COOKIE_SECURE'] = True
 app.config['DB_OFFLINE'] = DB_OFFLINE          # 供 template 使用
 app.register_blueprint(admin_bp)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pymongo==4.0.1
 pymongo[srv]==4.0.1
 flask-session==0.4.0
 werkzeug==2.3.8
+Flask-WTF==1.1.1

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <title>資料庫管理</title>
+<meta name="csrf-token" content="{{ csrf_token() }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
@@ -84,6 +85,8 @@
 <footer style="text-align:center;margin-top:20px;">版本: {{ version }}</footer>
 
 <script>
+const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+$.ajaxSetup({headers: {'X-CSRFToken': csrfToken}});
 let currentPage=1, perPage=20, sort="week_display", order=-1;
 
 function filters(){

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>使用者管理</title>
+  <meta name="csrf-token" content="{{ csrf_token() }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
@@ -22,6 +23,8 @@
   <a class="button" href="{{ url_for('index') }}">返回首頁</a>
 </div>
 <script>
+const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+$.ajaxSetup({headers: {'X-CSRFToken': csrfToken}});
 function loadUsers(){
   $.getJSON('/admin/users/data', users=>{
     const tb=$('#userTable tbody').empty();

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,6 +38,7 @@
         <p style="color: red; text-align: center;">{{ error }}</p>
         {% endif %}
         <form id="uploadForm" action="/upload" method="post" enctype="multipart/form-data" class="upload-form">
+            {{ csrf_token() }}
             <div class="button-container">
             <input type="file" name="file1" accept=".xls,.xlsx" class="upload-input">
             <input type="file" name="file2" accept=".xls,.xlsx" class="upload-input">

--- a/templates/login.html
+++ b/templates/login.html
@@ -31,6 +31,7 @@
         <p style="color: red; text-align: center;">{{ error }}</p>
         {% endif %}
         <form id="loginForm" action="{{ url_for('login') }}" method="post" class="form-group">
+            {{ csrf_token() }}
             <div class="form-group">
                 <label for="username">使用者名稱</label>
                 <input type="text" name="username" id="username" class="form-control" required>

--- a/templates/register.html
+++ b/templates/register.html
@@ -31,6 +31,7 @@
         <p style="color: red; text-align: center;">{{ error }}</p>
         {% endif %}
         <form id="registerForm" action="{{ url_for('register') }}" method="post" class="form-group">
+            {{ csrf_token() }}
             <div class="form-group">
                 <label for="username">使用者名稱</label>
                 <input type="text" name="username" id="username" class="form-control" required>


### PR DESCRIPTION
## Summary
- add Flask-WTF dependency
- secure session cookies and enable CSRF protection
- include CSRF tokens in forms and Ajax requests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip check`


------
https://chatgpt.com/codex/tasks/task_e_685b389bbbc48321841e4a97b6eaaf2e