### PR TITLE
Add password reset and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This is a Flask web application for analyzing attendance data from Excel files. 
 - Highlight names in light red if they attended last week but not this week.
 - Sort highlighted names to the top of the list.
 - Download the processed Excel file with new summary sheets.
+- Change password after logging in.
+- Reset password using username and registered email if you cannot log in.
 
 ## Prerequisites
 - Python 3.8 or higher

--- a/app.py
+++ b/app.py
@@ -22,7 +22,14 @@ from database import (
     get_year_trimmed_mean_by_event,
     get_year_trimmed_mean_by_age_group,
 )
-from user import init_users_collection, create_user, verify_user, create_admin_if_not_exists
+from user import (
+    init_users_collection,
+    create_user,
+    verify_user,
+    create_admin_if_not_exists,
+    change_password,
+    reset_password,
+)
 from config import db, DB_OFFLINE, COLLECTION_NAME
 from utils import parse_district, chinese_to_int, parse_week_display
 from datetime import datetime
@@ -217,6 +224,52 @@ def register():
             return redirect(url_for('login'))
         return render_template('register.html', error="使用者名稱已存在", version=get_version_info())
     return render_template('register.html', version=get_version_info())
+
+
+@app.route('/change_password', methods=['GET', 'POST'])
+def change_password_route():
+    if not is_authenticated():
+        return redirect(url_for('login'))
+
+    if request.method == 'POST':
+        old_pw = request.form.get('old_password')
+        new_pw = request.form.get('new_password')
+        if change_password(session['user']['username'], old_pw, new_pw):
+            session.pop('user', None)
+            return render_template(
+                'change_password.html',
+                success="密碼已更新，請重新登入",
+                version=get_version_info()
+            )
+        return render_template(
+            'change_password.html',
+            error="舊密碼不正確",
+            version=get_version_info()
+        )
+    return render_template('change_password.html', version=get_version_info())
+
+
+@app.route('/reset_password', methods=['GET', 'POST'])
+def reset_password_route():
+    if DB_OFFLINE:
+        return render_template(
+            'reset_password.html',
+            error="資料庫離線，無法重設密碼",
+            version=get_version_info()
+        )
+
+    if request.method == 'POST':
+        username = request.form.get('username')
+        email = request.form.get('email')
+        new_pw = request.form.get('new_password')
+        if reset_password(username, email, new_pw):
+            return redirect(url_for('login'))
+        return render_template(
+            'reset_password.html',
+            error="帳號與信箱不符",
+            version=get_version_info()
+        )
+    return render_template('reset_password.html', version=get_version_info())
 
 @app.route('/logout')
 def logout():

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+    <meta charset="UTF-8">
+    <title>變更密碼</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <style>
+        .login-container {max-width: 400px;margin: 50px auto;padding: 20px;background: #fff;border-radius: 8px;box-shadow: 0 0 10px rgba(0,0,0,0.1);}
+        .form-group {margin-bottom: 15px;}
+        .button-container {text-align: center;}
+    </style>
+</head>
+<body>
+    <div class="login-container">
+        <h2>變更密碼</h2>
+        {% if error %}
+        <p style="color: red; text-align: center;">{{ error }}</p>
+        {% elif success %}
+        <p style="color: green; text-align: center;">{{ success }}</p>
+        {% endif %}
+        <form action="{{ url_for('change_password_route') }}" method="post" class="form-group">
+            {{ csrf_token() }}
+            <div class="form-group">
+                <label for="old_password">舊密碼</label>
+                <input type="password" name="old_password" id="old_password" class="form-control" required>
+            </div>
+            <div class="form-group">
+                <label for="new_password">新密碼</label>
+                <input type="password" name="new_password" id="new_password" class="form-control" required>
+            </div>
+            <div class="button-container">
+                <button type="submit" class="button">變更</button>
+                <button type="button" class="button" onclick="window.location.href='{{ url_for('index') }}'">取消</button>
+            </div>
+        </form>
+    </div>
+    <footer style="text-align: center; margin-top: 20px;">
+        <p>版本: {{ version }}</p>
+    </footer>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -58,6 +58,7 @@
             <a href="{{ url_for('admin_bp.admin_home') }}" class="button admin">管理介面</a>
             {% endif %}
 
+            <a href="{{ url_for('change_password_route') }}" class="button">變更密碼</a>
             <a href="{{ url_for('logout') }}" class="button">登出</a>
         </div>
     </div>

--- a/templates/login.html
+++ b/templates/login.html
@@ -44,6 +44,7 @@
                 <button type="submit" class="button">登入</button>
                 <button type="button" class="button" onclick="window.location.href='{{ url_for('anonymous_login') }}'">匿名登入</button>
                 <button type="button" class="button" onclick="window.location.href='{{ url_for('register') }}'">註冊</button>
+                <button type="button" class="button" onclick="window.location.href='{{ url_for('reset_password_route') }}'">忘記密碼</button>
             </div>
         </form>
     </div>

--- a/templates/reset_password.html
+++ b/templates/reset_password.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+    <meta charset="UTF-8">
+    <title>重設密碼</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <style>
+        .register-container {max-width: 400px;margin: 50px auto;padding: 20px;background: #fff;border-radius: 8px;box-shadow: 0 0 10px rgba(0,0,0,0.1);}
+        .form-group {margin-bottom: 15px;}
+        .button-container {text-align: center;}
+    </style>
+</head>
+<body>
+    <div class="register-container">
+        <h2>重設密碼</h2>
+        {% if error %}
+        <p style="color: red; text-align: center;">{{ error }}</p>
+        {% endif %}
+        <form action="{{ url_for('reset_password_route') }}" method="post" class="form-group">
+            {{ csrf_token() }}
+            <div class="form-group">
+                <label for="username">使用者名稱</label>
+                <input type="text" name="username" id="username" class="form-control" required>
+            </div>
+            <div class="form-group">
+                <label for="email">註冊信箱</label>
+                <input type="email" name="email" id="email" class="form-control" required>
+            </div>
+            <div class="form-group">
+                <label for="new_password">新密碼</label>
+                <input type="password" name="new_password" id="new_password" class="form-control" required>
+            </div>
+            <div class="button-container">
+                <button type="submit" class="button">重設</button>
+                <button type="button" class="button" onclick="window.location.href='{{ url_for('login') }}'">返回登入</button>
+            </div>
+        </form>
+    </div>
+    <footer style="text-align: center; margin-top: 20px;">
+        <p>版本: {{ version }}</p>
+    </footer>
+</body>
+</html>

--- a/user.py
+++ b/user.py
@@ -134,3 +134,34 @@ def create_admin_if_not_exists(admin_username, admin_password):
         except Exception as e:
             logger.error(f"Failed to create admin user {admin_username}: {str(e)}")
             raise
+
+def change_password(username, old_password, new_password):
+    """Change password for a logged in user."""
+    if DB_OFFLINE:
+        logger.warning("離線模式：停用 change_password")
+        return False
+
+    collection = db["users"]
+    user = collection.find_one({"username": username})
+    if not user or not check_password_hash(user.get("password", ""), old_password):
+        return False
+
+    hashed = generate_password_hash(new_password, method='pbkdf2:sha256')
+    result = collection.update_one({"username": username}, {"$set": {"password": hashed}})
+    return result.modified_count == 1
+
+
+def reset_password(username, email, new_password):
+    """Reset password when the user cannot log in."""
+    if DB_OFFLINE:
+        logger.warning("離線模式：停用 reset_password")
+        return False
+
+    collection = db["users"]
+    user = collection.find_one({"username": username, "email": email})
+    if not user:
+        return False
+
+    hashed = generate_password_hash(new_password, method='pbkdf2:sha256')
+    result = collection.update_one({"username": username}, {"$set": {"password": hashed}})
+    return result.modified_count == 1


### PR DESCRIPTION
## Summary
- allow users to change their password after login
- add password reset using username/email when login fails
- link the new pages from login and index views
- document these features

## Testing
- `python -m py_compile user.py app.py admin_routes.py excel_handler.py render_table.py database.py utils.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_685b3c0108608321a5404986e93a5603