### PR TITLE
Align DB usage with MongoDB metrics

### DIFF
--- a/admin_routes.py
+++ b/admin_routes.py
@@ -248,12 +248,14 @@ def admin_db_status():
 
     # MongoDB dbStats
     stats = db.command("dbStats")
-    storage_mb = stats["storageSize"] / (1024 * 1024)          # 已用 MB
+    # 使用 dataSize + indexSize 以符合 MongoDB 網站的用量顯示
+    used_bytes = stats.get("dataSize", 0) + stats.get("indexSize", 0)
+    used_mb    = used_bytes / (1024 * 1024)
     quota_mb   = float(os.getenv("DB_QUOTA_MB", 512))          # 預設 512 MB，可用環境變數覆蓋
-    remain_mb  = max(0.0, quota_mb - storage_mb)
+    remain_mb  = max(0.0, quota_mb - used_mb)
 
     return jsonify({
-        "storage_mb": round(storage_mb, 1),
+        "used_mb":   round(used_mb, 1),
         "quota_mb":   quota_mb,
         "remain_mb":  round(remain_mb, 1),
         "collections": stats["collections"],

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -185,7 +185,7 @@ $(document).ready(()=>loadPage(1));
 function loadDbStatus(){
   $.getJSON('/admin/db_status', res=>{
       $('#dbStatus').text(
-        `資料庫已用 ${res.storage_mb} MB / ${res.quota_mb} MB，`+
+        `資料庫已用 ${res.used_mb} MB / ${res.quota_mb} MB，`+
         `剩餘 ${res.remain_mb} MB ｜ `+
         `Collections: ${res.collections} ｜ Documents: ${res.objects}`
       );


### PR DESCRIPTION
## Summary
- show DB usage based on `dataSize + indexSize`
- update admin page to use `used_mb`

## Testing
- `python -m py_compile admin_routes.py config.py excel_handler.py render_table.py user.py utils.py app.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_685df9507cf48321b8973edab50fb61c