### PR TITLE
Add basic event logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This is a Flask web application for analyzing attendance data from Excel files. 
 - Download the processed Excel file with new summary sheets.
 - Change password after logging in.
 - Reset password using username and registered email if you cannot log in.
+- Event log tracks logins and admin actions (keeps last 100k entries).
 
 ## Prerequisites
 - Python 3.8 or higher

--- a/admin_routes.py
+++ b/admin_routes.py
@@ -10,6 +10,7 @@ import csv, re, os, math
 from config import db, DB_OFFLINE, COLLECTION_NAME
 from user import update_user_role, block_user, unblock_user, delete_user
 from utils import parse_week_display   # 若後續用不到可移除
+from eventlog import log_event
 
 # --- helper: avoid circular import ---
 def is_admin():
@@ -78,6 +79,8 @@ def admin_update_role():
     username = request.json.get("username")
     new_role = request.json.get("role")
     ok = update_user_role(username, new_role)
+    if ok:
+        log_event("admin_update_role", session.get('user', {}).get('username'), details={"target": username, "role": new_role})
     return jsonify({"success": ok})
 
 # ------------------------------------------------------------------------------
@@ -89,6 +92,8 @@ def admin_block():
         return jsonify({"error":"forbidden"}), 403
     username = request.json.get("username")
     ok = block_user(username)
+    if ok:
+        log_event("admin_block", session.get('user', {}).get('username'), details={"target": username})
     return jsonify({"success": ok})
 
 @admin_bp.route("/users/unblock", methods=["POST"])
@@ -97,6 +102,8 @@ def admin_unblock():
         return jsonify({"error":"forbidden"}), 403
     username = request.json.get("username")
     ok = unblock_user(username)
+    if ok:
+        log_event("admin_unblock", session.get('user', {}).get('username'), details={"target": username})
     return jsonify({"success": ok})
 
 # ------------------------------------------------------------------------------
@@ -108,6 +115,8 @@ def admin_delete_user():
         return jsonify({"error":"forbidden"}), 403
     username = request.json.get("username")
     ok = delete_user(username)
+    if ok:
+        log_event("admin_delete_user", session.get('user', {}).get('username'), details={"target": username})
     return jsonify({"success": ok})
 
 # ------------------------------------------------------------------------------

--- a/app.py
+++ b/app.py
@@ -30,6 +30,7 @@ from user import (
     change_password,
     reset_password,
 )
+from eventlog import init_eventlog_collection, log_event
 from config import db, DB_OFFLINE, COLLECTION_NAME
 from utils import parse_district, chinese_to_int, parse_week_display
 from datetime import datetime
@@ -66,6 +67,7 @@ if not DB_OFFLINE:
         if not (admin_username and admin_password):
             raise ValueError("Admin credentials not set")
         create_admin_if_not_exists(admin_username, admin_password)
+        init_eventlog_collection()
         logger.info("資料庫初始化完成")
     except Exception as e:
         logger.error(f"DB init error: {e}")
@@ -192,7 +194,9 @@ def login():
                 'role': user['role']
             }
             logger.info(f"User {username} logged in successfully")
+            log_event("login", username=user['username'])
             return redirect(url_for('index'))
+        log_event("login_failed", username=username)
         return render_template('login.html', error="無效的使用者名稱或密碼", version=get_version_info())
     return render_template('login.html', version=get_version_info())
 
@@ -203,6 +207,7 @@ def anonymous_login():
         'role': 'anonymous'
     }
     logger.info("Anonymous user logged in")
+    log_event("anonymous_login")
     return redirect(url_for('index'))
 
 @app.route('/register', methods=['GET', 'POST'])
@@ -221,6 +226,7 @@ def register():
         password = request.form.get('password')
         if create_user(username, email, password):
             logger.info(f"User {username} registered successfully")
+            log_event("register", username=username)
             return redirect(url_for('login'))
         return render_template('register.html', error="使用者名稱已存在", version=get_version_info())
     return render_template('register.html', version=get_version_info())
@@ -235,6 +241,7 @@ def change_password_route():
         old_pw = request.form.get('old_password')
         new_pw = request.form.get('new_password')
         if change_password(session['user']['username'], old_pw, new_pw):
+            log_event("change_password", username=session['user']['username'])
             session.pop('user', None)
             return render_template(
                 'change_password.html',
@@ -263,6 +270,7 @@ def reset_password_route():
         email = request.form.get('email')
         new_pw = request.form.get('new_password')
         if reset_password(username, email, new_pw):
+            log_event("reset_password", username=username)
             return redirect(url_for('login'))
         return render_template(
             'reset_password.html',
@@ -275,6 +283,7 @@ def reset_password_route():
 def logout():
     session.pop('user', None)
     logger.info("User logged out")
+    log_event("logout")
     return redirect(url_for('login'))
 
 @app.route('/upload', methods=['POST'])
@@ -310,6 +319,11 @@ def upload_file():
             save_to_db=(not is_anonymous and not DB_OFFLINE)
         )
         logger.info(f"Started background task: {task_id}")
+        log_event(
+            "upload",
+            username=session.get('user', {}).get('username'),
+            details={"file_count": len(files)}
+        )
         return jsonify({"task_id": task_id}), 202
     except Exception as e:
         logger.error(f"Failed to start task: {str(e)}")

--- a/eventlog.py
+++ b/eventlog.py
@@ -1,0 +1,59 @@
+import logging
+from datetime import datetime
+from config import db, DB_OFFLINE
+
+logger = logging.getLogger(__name__)
+
+COLLECTION_NAME = "event_log"
+MAX_ENTRIES = 100000
+
+
+def init_eventlog_collection():
+    """Ensure event_log collection exists and has an index on ts."""
+    if DB_OFFLINE:
+        logger.warning("離線模式：跳過 event_log 初始化")
+        return
+
+    if COLLECTION_NAME not in db.list_collection_names():
+        try:
+            db.create_collection(COLLECTION_NAME)
+            logger.info("Created event_log collection")
+        except Exception as e:
+            logger.error(f"Failed to create event_log collection: {e}")
+
+    try:
+        db[COLLECTION_NAME].create_index("ts")
+    except Exception as e:
+        logger.error(f"Failed to create index on event_log.ts: {e}")
+
+
+def _enforce_limit():
+    """Ensure only MAX_ENTRIES newest documents are kept."""
+    try:
+        cnt = db[COLLECTION_NAME].estimated_document_count()
+        if cnt > MAX_ENTRIES:
+            skip = cnt - MAX_ENTRIES
+            old = db[COLLECTION_NAME].find({}, {"_id": 1}).sort("ts", 1).limit(skip)
+            ids = [d["_id"] for d in old]
+            if ids:
+                db[COLLECTION_NAME].delete_many({"_id": {"$in": ids}})
+    except Exception as e:
+        logger.error(f"Failed to enforce event_log limit: {e}")
+
+
+def log_event(action, username=None, details=None):
+    """Write an event log entry."""
+    if DB_OFFLINE:
+        return
+    doc = {
+        "action": action,
+        "username": username,
+        "details": details,
+        "ts": datetime.utcnow(),
+    }
+    try:
+        db[COLLECTION_NAME].insert_one(doc)
+        _enforce_limit()
+    except Exception as e:
+        logger.error(f"Failed to log event: {e}")
+


### PR DESCRIPTION
## Summary
- implement `eventlog.py` with capped log
- initialize and use event logging in the Flask app
- record events for login and various admin actions
- document the new feature in the README

## Testing
- `python -m py_compile eventlog.py app.py admin_routes.py user.py database.py`
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_685dfbbc0d108321ac843a775b4446a9