### PR TITLE
Implement event log viewer in admin UI

### DIFF
--- a/admin_routes.py
+++ b/admin_routes.py
@@ -270,3 +270,46 @@ def admin_db_status():
         "collections": stats["collections"],
         "objects":     stats["objects"]
     })
+
+# ------------------------------------------------------------------------------
+#  Event log viewer
+# ------------------------------------------------------------------------------
+@admin_bp.route("/logs")
+def admin_logs():
+    if DB_OFFLINE:
+        return "Database offline", 503
+    if not is_admin():
+        return "Forbidden", 403
+    log_event("view_event_logs", session.get('user', {}).get('username'))
+    return render_template("admin_logs.html", version=current_app.config.get("VERSION", "dev"))
+
+
+@admin_bp.route("/logs/data")
+def admin_logs_data():
+    if DB_OFFLINE:
+        return jsonify({"error": "db offline"}), 503
+    if not is_admin():
+        return jsonify({"error": "forbidden"}), 403
+
+    page     = int(request.args.get("page", 1))
+    per_page = int(request.args.get("per_page", 20))
+    sort_by  = request.args.get("sort", "ts")
+    order    = int(request.args.get("order", -1))
+
+    cursor = db["event_log"].find().sort(sort_by, order)
+    total  = db["event_log"].count_documents({})
+    cursor = cursor.skip((page - 1) * per_page).limit(per_page)
+
+    records = []
+    for doc in cursor:
+        ts = doc.get("ts")
+        if isinstance(ts, datetime):
+            ts = ts.strftime("%Y-%m-%d %H:%M:%S")
+        records.append({
+            "ts": ts,
+            "action": doc.get("action", ""),
+            "username": doc.get("username", ""),
+            "details": doc.get("details")
+        })
+
+    return jsonify({"total": total, "records": records})

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -27,6 +27,7 @@
   <!-- 2. 使用者管理 -->
   <div class="mb-3">
     <a class="button" href="{{ url_for('admin_bp.admin_users') }}">使用者管理</a>
+    <a class="button" href="{{ url_for('admin_bp.admin_logs') }}">事件紀錄</a>
   </div>
   <!-- 3. 資料庫狀態 -->
   <div id="dbStatus" class="alert alert-info py-2 px-3" role="alert">

--- a/templates/admin_logs.html
+++ b/templates/admin_logs.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=yes">
+  <title>事件紀錄</title>
+  <meta name="csrf-token" content="{{ csrf_token() }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+</head>
+<body>
+<div class="container">
+  <h2>事件紀錄</h2>
+  <div class="table-container">
+    <table class="excel-table" id="logTable">
+      <thead>
+        <tr>
+          <th data-field="ts">時間</th>
+          <th data-field="action">動作</th>
+          <th data-field="username">使用者</th>
+          <th>詳細資訊</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+  <nav><ul class="pagination" id="pager"></ul></nav>
+  <a class="button" href="{{ url_for('admin_bp.admin_home') }}">返回資料管理</a>
+  <a class="button" href="{{ url_for('index') }}">返回首頁</a>
+</div>
+<script>
+const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+$.ajaxSetup({headers: {'X-CSRFToken': csrfToken}});
+let currentPage=1, perPage=20, sort='ts', order=-1;
+function loadPage(p=1){
+  currentPage=p;
+  $.getJSON('/admin/logs/data', {page:p, per_page:perPage, sort, order}, renderTable)
+   .fail(e=>alert('載入失敗:'+e.responseJSON?.error));
+}
+function renderTable(res){
+  const tb=$('#logTable tbody').empty();
+  res.records.forEach(r=>{
+    const details= r.details ? JSON.stringify(r.details) : '';
+    tb.append(`<tr><td>${r.ts}</td><td>${r.action}</td><td>${r.username||''}</td><td>${details}</td></tr>`);
+  });
+  const pages=Math.ceil(res.total/perPage);
+  const pg=$('#pager').empty();
+  for(let i=1;i<=pages;i++){
+    pg.append(`<li class="page-item ${i===currentPage?'active':''}"><a class="page-link" href="javascript:loadPage(${i})">${i}</a></li>`);
+  }
+}
+$('#logTable th[data-field]').on('click',function(){
+  const f=$(this).data('field');
+  if(sort===f){order*=-1;}else{sort=f;order=-1;}
+  loadPage(1);
+});
+$(document).ready(()=>loadPage(1));
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new "事件紀錄" link on the admin page
- implement `/admin/logs` and `/admin/logs/data` routes for event logs
- create a template to display logs with pagination
- log viewing of event logs

## Testing
- `python -m py_compile admin_routes.py eventlog.py app.py user.py`

------
https://chatgpt.com/codex/tasks/task_e_685e75ecd71883218bfeb7f80dbbf759