### PR TITLE
Implement event log archiving

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a Flask web application for analyzing attendance data from Excel files. 
 - Download the processed Excel file with new summary sheets.
 - Change password after logging in.
 - Reset password using username and registered email if you cannot log in.
-- Event log tracks logins and admin actions (keeps last 100k entries).
+- Event log tracks logins and admin actions (keeps last 100k entries and archives older records).
 
 ## Prerequisites
 - Python 3.8 or higher

--- a/eventlog.py
+++ b/eventlog.py
@@ -5,11 +5,12 @@ from config import db, DB_OFFLINE
 logger = logging.getLogger(__name__)
 
 COLLECTION_NAME = "event_log"
+ARCHIVE_COLLECTION_NAME = "event_log_archive"
 MAX_ENTRIES = 100000
 
 
 def init_eventlog_collection():
-    """Ensure event_log collection exists and has an index on ts."""
+    """Ensure event_log collections exist and have indexes on ``ts``."""
     if DB_OFFLINE:
         logger.warning("離線模式：跳過 event_log 初始化")
         return
@@ -26,6 +27,30 @@ def init_eventlog_collection():
     except Exception as e:
         logger.error(f"Failed to create index on event_log.ts: {e}")
 
+    if ARCHIVE_COLLECTION_NAME not in db.list_collection_names():
+        try:
+            db.create_collection(ARCHIVE_COLLECTION_NAME)
+            logger.info("Created event_log_archive collection")
+        except Exception as e:
+            logger.error(f"Failed to create event_log_archive collection: {e}")
+
+    try:
+        db[ARCHIVE_COLLECTION_NAME].create_index("ts")
+    except Exception as e:
+        logger.error(f"Failed to create index on event_log_archive.ts: {e}")
+
+
+def _archive_old_entries(docs):
+    """Move old log entries to the archive collection."""
+    try:
+        if not docs:
+            return
+        for d in docs:
+            d.pop("_id", None)
+        db[ARCHIVE_COLLECTION_NAME].insert_many(docs)
+    except Exception as e:
+        logger.error(f"Failed to archive event_log entries: {e}")
+
 
 def _enforce_limit():
     """Ensure only MAX_ENTRIES newest documents are kept."""
@@ -33,9 +58,11 @@ def _enforce_limit():
         cnt = db[COLLECTION_NAME].estimated_document_count()
         if cnt > MAX_ENTRIES:
             skip = cnt - MAX_ENTRIES
-            old = db[COLLECTION_NAME].find({}, {"_id": 1}).sort("ts", 1).limit(skip)
-            ids = [d["_id"] for d in old]
-            if ids:
+            cursor = db[COLLECTION_NAME].find().sort("ts", 1).limit(skip)
+            old_docs = list(cursor)
+            if old_docs:
+                _archive_old_entries(old_docs)
+                ids = [d["_id"] for d in old_docs if "_id" in d]
                 db[COLLECTION_NAME].delete_many({"_id": {"$in": ids}})
     except Exception as e:
         logger.error(f"Failed to enforce event_log limit: {e}")


### PR DESCRIPTION
## Summary
- keep event log under 100k entries by archiving oldest documents to `event_log_archive`
- document archiving behavior in README

## Testing
- `python -m py_compile eventlog.py admin_routes.py app.py database.py excel_handler.py render_table.py user.py utils.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_685e8864e6a483218a28d6f52a187fdd