### PR TITLE
Remove event log archiving

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a Flask web application for analyzing attendance data from Excel files. 
 - Download the processed Excel file with new summary sheets.
 - Change password after logging in.
 - Reset password using username and registered email if you cannot log in.
-- Event log tracks logins and admin actions (keeps last 100k entries and archives older records).
+- Event log tracks logins and admin actions (keeps last 100k entries and discards older records).
 
 ## Prerequisites
 - Python 3.8 or higher

--- a/eventlog.py
+++ b/eventlog.py
@@ -5,7 +5,6 @@ from config import db, DB_OFFLINE
 logger = logging.getLogger(__name__)
 
 COLLECTION_NAME = "event_log"
-ARCHIVE_COLLECTION_NAME = "event_log_archive"
 MAX_ENTRIES = 100000
 
 
@@ -27,43 +26,19 @@ def init_eventlog_collection():
     except Exception as e:
         logger.error(f"Failed to create index on event_log.ts: {e}")
 
-    if ARCHIVE_COLLECTION_NAME not in db.list_collection_names():
-        try:
-            db.create_collection(ARCHIVE_COLLECTION_NAME)
-            logger.info("Created event_log_archive collection")
-        except Exception as e:
-            logger.error(f"Failed to create event_log_archive collection: {e}")
-
-    try:
-        db[ARCHIVE_COLLECTION_NAME].create_index("ts")
-    except Exception as e:
-        logger.error(f"Failed to create index on event_log_archive.ts: {e}")
-
-
-def _archive_old_entries(docs):
-    """Move old log entries to the archive collection."""
-    try:
-        if not docs:
-            return
-        for d in docs:
-            d.pop("_id", None)
-        db[ARCHIVE_COLLECTION_NAME].insert_many(docs)
-    except Exception as e:
-        logger.error(f"Failed to archive event_log entries: {e}")
+    # Old entries will be discarded once the log exceeds MAX_ENTRIES
 
 
 def _enforce_limit():
-    """Ensure only MAX_ENTRIES newest documents are kept."""
+    """Delete oldest entries when count exceeds ``MAX_ENTRIES``."""
     try:
         cnt = db[COLLECTION_NAME].estimated_document_count()
         if cnt > MAX_ENTRIES:
             skip = cnt - MAX_ENTRIES
             cursor = db[COLLECTION_NAME].find().sort("ts", 1).limit(skip)
-            old_docs = list(cursor)
-            if old_docs:
-                _archive_old_entries(old_docs)
-                ids = [d["_id"] for d in old_docs if "_id" in d]
-                db[COLLECTION_NAME].delete_many({"_id": {"$in": ids}})
+            old_ids = [d["_id"] for d in cursor if "_id" in d]
+            if old_ids:
+                db[COLLECTION_NAME].delete_many({"_id": {"$in": old_ids}})
     except Exception as e:
         logger.error(f"Failed to enforce event_log limit: {e}")
 


### PR DESCRIPTION
## Summary
- keep event logs up to 100k records
- discard older logs instead of archiving them
- update README to reflect new behaviour

## Testing
- `python -m py_compile eventlog.py app.py admin_routes.py user.py database.py`


------
https://chatgpt.com/codex/tasks/task_e_685e96f522688321b9e748e16d571f59